### PR TITLE
Update community and event links with icon-based buttons

### DIFF
--- a/_pages/index.html
+++ b/_pages/index.html
@@ -96,11 +96,17 @@ excerpt: "**Connecting Kansas City's data community.**"
         We'll add Slack or Discord in the future, but for now these are the best places to connect.
     </p>
 
-    <a href="https://www.meetup.com/kcdataprofessionals/" rel="noopener noreferrer nofollow" target="_blank" class="btn btn--primary">
-        Join on Meetup
+    <a href="https://www.linkedin.com/company/kcdataprofessionals" rel="noopener noreferrer nofollow" target="_blank" class="btn btn--primary">
+        <i class="fa-brands fa-linkedin" aria-hidden="true"></i>
+        Follow KCDP
     </a>
     <a href="https://www.linkedin.com/groups/15848016/" rel="noopener noreferrer nofollow" target="_blank" class="btn btn--primary">
-        Join on LinkedIn
+        <i class="fa-brands fa-linkedin" aria-hidden="true"></i>
+        Join KCDP
+    </a>
+    <a href="https://www.meetup.com/kcdataprofessionals/" rel="noopener noreferrer nofollow" target="_blank" class="btn btn--primary">
+        <i class="fa-brands fa-meetup" aria-hidden="true"></i>
+        Join KCDP
     </a>
 
 </section>
@@ -120,15 +126,21 @@ excerpt: "**Connecting Kansas City's data community.**"
         <div class="box box--primary box-half">
             <h4>Next Event</h4>
             <p>Register here for the upcoming session.</p>
-            <a href="https://luma.com/6qaldwjl" rel="noopener noreferrer nofollow" target="_blank" class="btn btn--primary btn--small">
-                Register on Luma
+            <a href="https://luma.com/zqe0cwh2?tk=EmWgjU" rel="noopener noreferrer nofollow" target="_blank" class="btn btn--primary btn--small">
+                <i class="fa-solid fa-star" aria-hidden="true"></i>
+                Register for Next Event
+            </a>
+            <a href="https://www.meetup.com/kcdataprofessionals/events/313572998" rel="noopener noreferrer nofollow" target="_blank" class="btn btn--primary btn--small">
+                <i class="fa-brands fa-meetup" aria-hidden="true"></i>
+                Meetup Event
             </a>
         </div>
         <div class="box box--primary box-half">
             <h4>All Events</h4>
             <p>See the full schedule and RSVP on Meetup.</p>
-            <a href="https://www.meetup.com/kcdataprofessionals/" rel="noopener noreferrer nofollow" target="_blank" class="btn btn--primary btn--small">
-                View on Meetup
+            <a href="https://www.meetup.com/kcdataprofessionals/events/calendar/" rel="noopener noreferrer nofollow" target="_blank" class="btn btn--primary btn--small">
+                <i class="fa-brands fa-meetup" aria-hidden="true"></i>
+                View All Events
             </a>
         </div>
     </div>


### PR DESCRIPTION
### Motivation
- Add a direct LinkedIn company-page link and improve the Join the Community links to surface platform logos and shorter labels.
- Make the join links order Follow KCDP → Join KCDP (LinkedIn group) → Join KCDP (Meetup) for clarity.
- Update Events & Registration links to point to the new Luma RSVP, add a specific Meetup event, and point All Events to the Meetup calendar.

### Description
- Edited `
_pages/index.html` to add a new LinkedIn company link, reorder the community links, and replace text labels with icon-first buttons using Font Awesome classes (e.g. `fa-brands fa-linkedin`, `fa-brands fa-meetup`).
- Replaced the Luma RSVP URL with `https://luma.com/zqe0cwh2?tk=EmWgjU`, added the Meetup event link `https://www.meetup.com/kcdataprofessionals/events/313572998`, and updated the All Events link to `https://www.meetup.com/kcdataprofessionals/events/calendar/`.
- Created branch `feature/update-community-event-links` and committed the changes in `935e052`.

### Testing
- Attempted `jekyll build`, which failed in this environment because `jekyll` is not installed. (failed)
- Served the site with `python3 -m http.server 4000` and captured a visual verification screenshot via Playwright, which succeeded. (passed)
- Changes were staged and committed with `git commit` to record the update. (completed)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a301323d9083309960e946c9707261)