### PR TITLE
Update next event details for April 30, 2026

### DIFF
--- a/_pages/index.html
+++ b/_pages/index.html
@@ -19,7 +19,7 @@ header:
           url: https://www.linkedin.com/groups/15848016/
           blank: true
         - label: "Register for Next Event"
-          url: https://luma.com/6qaldwjl
+          url: https://luma.com/7jxz3vkp
           blank: true
 
     caption: "Kansas City skyline"
@@ -119,9 +119,14 @@ excerpt: "**Connecting Kansas City's data community.**"
     <div class="box-container">
         <div class="box box--primary box-half">
             <h4>Next Event</h4>
-            <p>Register here for the upcoming session.</p>
-            <a href="https://luma.com/6qaldwjl" rel="noopener noreferrer nofollow" target="_blank" class="btn btn--primary btn--small">
+            <p><strong>Unifying transactional and analytical data with Postgres</strong><br>
+            Thursday, April 30 · 5:30–7:00 PM CT<br>
+            KC Digital Drive, Kansas City, MO</p>
+            <a href="https://luma.com/7jxz3vkp" rel="noopener noreferrer nofollow" target="_blank" class="btn btn--primary btn--small">
                 Register on Luma
+            </a>
+            <a href="https://www.meetup.com/kcdataprofessionals/events/314190934/" rel="noopener noreferrer nofollow" target="_blank" class="btn btn--primary btn--small">
+                Register on Meetup
             </a>
         </div>
         <div class="box box--primary box-half">


### PR DESCRIPTION
## Changes

- Updated event registration link from `luma.com/6qaldwjl` to `luma.com/7jxz3vkp`
- Added event details:
  - **Title:** Unifying transactional and analytical data with Postgres
  - **Date/Time:** Thursday, April 30 · 5:30–7:00 PM CT
  - **Location:** KC Digital Drive, Kansas City, MO
- Added Meetup registration link alongside Luma registration
- Updated both header and main event sections with new registration URLs

## Files Modified

- `_pages/index.html`: Updated event information and registration links