### PR TITLE
Update registration links and event details to next Luma event

### DIFF
--- a/_pages/index.html
+++ b/_pages/index.html
@@ -19,7 +19,7 @@ header:
           url: https://www.linkedin.com/groups/15848016/
           blank: true
         - label: "Register for Next Event"
-          url: https://luma.com/j1w0gwyy
+          url: https://luma.com/pr264cb8
           blank: true
 
     caption: "Kansas City skyline"
@@ -125,14 +125,14 @@ excerpt: "**Connecting Kansas City's data community.**"
     <div class="box-container">
         <div class="box box--primary box-half">
             <h4>Next Event</h4>
-            <p><strong>Unifying transactional and analytical data with Postgres</strong><br>
-            Thursday, April 30 · 5:30–7:00 PM CT<br>
+            <p><strong>Plot Twist: How These Data Pros Actually Got Where They Are</strong><br>
+            Thursday, July 30 · 5:30–7:00 PM CT<br>
             KC Digital Drive, Kansas City, MO</p>
-            <a href="https://luma.com/j1w0gwyy" rel="noopener noreferrer nofollow" target="_blank" class="btn btn--primary btn--small">
+            <a href="https://luma.com/pr264cb8" rel="noopener noreferrer nofollow" target="_blank" class="btn btn--primary btn--small">
                 <i class="fa-solid fa-star" aria-hidden="true"></i>
                 Register on Luma
             </a>
-            <a href="https://www.meetup.com/kcdataprofessionals/events/314190934/" rel="noopener noreferrer nofollow" target="_blank" class="btn btn--primary btn--small">
+            <a href="https://www.meetup.com/kcdataprofessionals/events/315246536/" rel="noopener noreferrer nofollow" target="_blank" class="btn btn--primary btn--small">
                 <i class="fa-brands fa-meetup" aria-hidden="true"></i>
                 Register on Meetup
             </a>


### PR DESCRIPTION
## Summary
- Point the header "Register for Next Event" button and the Next Event box's "Register on Luma" button to the next event (https://luma.com/pr264cb8)
- Update the Next Event box title, date, and Meetup registration link to match the new event: "Plot Twist: How These Data Pros Actually Got Where They Are", Thursday, July 30 · 5:30–7:00 PM CT, at KC Digital Drive

## Test plan
- [x] Confirmed event details (title, date/time, venue) against the live Luma and Meetup event pages
- [ ] Visually verify the homepage Next Event section renders correctly